### PR TITLE
Allow specifying synthetic source path for string scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 LPC2J is an [LPC90](https://protasm.github.io/LPC90)-compatible compiler for creating Java classfiles from LPC (i.e. LPMud) source code.
+
+## Scanner usage
+
+When scanning source from an in-memory string that contains relative `#include`
+directives, supply a synthetic source path so that the preprocessor searches the
+correct directory:
+
+```java
+Scanner scanner = new Scanner();
+TokenList tokens = scanner.scan(
+    sourceText,
+    "/usr/local/include",         // system include path
+    "/path/to/source/dir",        // quote include path
+    Path.of("/path/to/source.lpc") // pretend file location
+);
+```
+

--- a/src/io/github/protasm/lpc2j/scanner/Scanner.java
+++ b/src/io/github/protasm/lpc2j/scanner/Scanner.java
@@ -153,21 +153,38 @@ public class Scanner {
                 return scan(source, file.getParent().toString(), file.getParent().toString(), file);
         }
 
-        private TokenList scan(String source, String sysInclPath, String quoteInclPath, Path sourceFile) {
-                preprocess(source, sourceFile, sysInclPath, quoteInclPath);
+       /**
+        * Scan an LPC source string, optionally pretending it resides at
+        * {@code sourceFile}.
+        * <p>
+        * Supplying a non {@code null} {@code sourceFile} allows relative
+        * {@code #include "..."} directives to resolve against that file's
+        * parent directory. This is handy when the source code originates from an
+        * in-memory string rather than an actual file on disk.
+        *
+        * @param source        LPC source text
+        * @param sysInclPath   base directory for {@code <...>} includes
+        * @param quoteInclPath base directory for {@code "..."} includes when
+        *                      {@code sourceFile} lacks a parent
+        * @param sourceFile    absolute or synthetic path of the source, or
+        *                      {@code null}
+        * @return list of tokens produced by scanning the source
+        */
+       public TokenList scan(String source, String sysInclPath, String quoteInclPath, Path sourceFile) {
+               preprocess(source, sourceFile, sysInclPath, quoteInclPath);
 
-                TokenList tokens = new TokenList();
-                Token<?> token;
+               TokenList tokens = new TokenList();
+               Token<?> token;
 
-                do {
-                        token = lexToken();
+               do {
+                       token = lexToken();
 
-                        if (token != null)
-                                tokens.add(token);
-                } while ((token == null) || (token.type() != T_EOF));
+                       if (token != null)
+                               tokens.add(token);
+               } while ((token == null) || (token.type() != T_EOF));
 
-                return tokens;
-        }
+               return tokens;
+       }
 
         private Token<?> lexToken() {
 		if (ss.atEnd())


### PR DESCRIPTION
## Summary
- expose a public `Scanner.scan` overload that accepts a `Path` to represent the source file, enabling relative `#include` resolution when scanning from a string
- document scanner usage with synthetic paths to fix include lookup issues

## Testing
- `javac -cp "libs/*" @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b6d3ace3cc83278cbc0f9fa61d4ada