### PR TITLE
Refactor scanner preprocessing

### DIFF
--- a/src/io/github/protasm/lpc2j/LPC2J.java
+++ b/src/io/github/protasm/lpc2j/LPC2J.java
@@ -101,8 +101,12 @@ public class LPC2J {
 			if (!success)
 				throw new IllegalArgumentException();
 
-			Scanner scanner = new Scanner();
-			TokenList tokens = scanner.scan(sf.source());
+                        Scanner scanner = new Scanner();
+                        Path absResolved = basePath.basePath().resolve(resolved);
+                        TokenList tokens = scanner.scan(sf.source(),
+                                        basePath.basePath().toString(),
+                                        absResolved.getParent().toString(),
+                                        absResolved);
 
 			sf.setTokens(tokens);
 


### PR DESCRIPTION
## Summary
- Move include resolution and preprocessor creation into a new static `Preprocessor.preprocess` helper to decouple it from the scanner.
- Simplify `Scanner.scan` to call the new helper and manage only tokenization.
- Update `LPC2J` to supply include paths and use the revised scanner API.

## Testing
- `javac -cp "libs/*" -d out @sources.list`


------
https://chatgpt.com/codex/tasks/task_e_68b7778843c48327a34a4a58d4dd881b