### PR TITLE
Add JSON-backed virtual room plumbing

### DIFF
--- a/domain/original/world/virtual_room.c
+++ b/domain/original/world/virtual_room.c
@@ -1,0 +1,40 @@
+inherit "/room/room.c";
+
+void configure_room(string room_id);
+
+void create() {
+    string name;
+    string *parts;
+
+    ::create();
+
+    name = object_name(this_object());
+    parts = explode(name, "#");
+    if (sizeof(parts) < 2) {
+        return;
+    }
+
+    configure_room(parts[1]);
+}
+
+void configure_room(string room_id) {
+    mapping data;
+    mapping exits;
+    string direction;
+    string destination;
+
+    data = "/domain/original/world/world_loader"->get_room_data(room_id);
+    if (!mapp(data)) {
+        return;
+    }
+
+    set_short("Virtual room " + room_id);
+    set_long("This is a virtual room.");
+
+    exits = data["exits"];
+    if (mapp(exits)) {
+        foreach (direction, destination in exits) {
+            add_exit(direction, "/domain/original/world/vroom#" + destination);
+        }
+    }
+}

--- a/domain/original/world/world_loader.c
+++ b/domain/original/world/world_loader.c
@@ -1,0 +1,36 @@
+mapping _room_data;
+int _loaded;
+
+void load_world() {
+    string raw;
+    mixed decoded;
+
+    if (_loaded) {
+        return;
+    }
+
+    _loaded = 1;
+    raw = read_file("/domain/original/world/world.json");
+    if (!stringp(raw)) {
+        _room_data = ([]);
+        return;
+    }
+
+    decoded = json_decode(raw);
+    if (mapp(decoded)) {
+        _room_data = decoded;
+        return;
+    }
+
+    _room_data = ([]);
+}
+
+mapping get_room_data(string room_id) {
+    load_world();
+
+    if (!mapp(_room_data)) {
+        return 0;
+    }
+
+    return _room_data[room_id];
+}


### PR DESCRIPTION
### Motivation
- Provide core plumbing for a JSON-backed virtual room system so rooms can be instantiated by id and configured from a centralized world definition.
- Support virtual object names of the form `/domain/original/world/vroom#<room_id>` and allow the world to drive terrain and exits.
- Keep parsing and storage of the JSON world separate from the virtual room object logic.

### Description
- Added `domain/original/world/virtual_room.c` which inherits `"/room/room.c"`, extracts the `room_id` fragment from the object name, and defines `configure_room(string room_id)` to configure the instance using loader data.
- `virtual_room.c` sets a short description using only the `room_id`, a neutral long description, and adds exits from the loader mapping using `add_exit(direction, "/domain/original/world/vroom#" + destination)` without hardcoding any room ids.
- Added `domain/original/world/world_loader.c` which lazily loads and parses `/domain/original/world/world.json` exactly once using `read_file()` and `json_decode()`, stores parsed data in a mapping keyed by `room_id`, and exposes `mapping get_room_data(string room_id)` that returns the mapping or `0` for unknown ids.
- The loader is safe to call repeatedly and avoids reparsing after the initial load.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9d22c3f483278ee404bddc7ce267)